### PR TITLE
Added style to Facebook and Twitter Links

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
             <a href="https://twitter.com/CodeForAnc" id="twitter" class="button"><span>Twitter</span></a>
           </section>
           <section id="downloads" class="clearfix">
-            <a href="https://www.facebook.com/codeforanc"" id="facebook" class="button"><span>Facebook</span></a>
+            <a href="https://www.facebook.com/codeforanc" id="facebook" class="button"><span>Facebook</span></a>
           </section>
           <section id="downloads" class="clearfix">
             <a href="http://www.meetup.com/Code-for-Anchorage" id="meetup" class="button"><span>Meetup</span></a>


### PR DESCRIPTION
The meetup, google groups, and github links all have the clearfix class styling. I added this to Facebook and Twitter links to make them consistent.
