### PR TITLE
Update "Donate" link to new CfA Donate page

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,7 +117,7 @@
         <section>
           <h1>Donate to Code for Anchorage</h1>
 
-          <a href="https://secure.codeforamerica.org/page/contribute/donate-to-a-brigade-today?source_codes=Brigade-page&brigade=Code%20for%20Anchorage" class="button" style="text-align:center">Donate</a>
+          <a href="https://www.codeforamerica.org/donate-to-a-brigade?utm_campaign=Code%20for%20Anchorage&utm_source=CodeForAnchorageSite" class="button" style="text-align:center">Donate</a>
 
           <p>Code for Anchorage is a volunteer non-profit group under
           501c3 <a href="http://www.codeforamerica.org">Code for America</a> and relies on donations


### PR DESCRIPTION
We created this new donate page [seven months ago][1] because the old
donate page required a high maintenance burden and created an
unnecessary duplication in our process.

This commit updates your website to link to the new Donate page.

[1]: https://groups.google.com/a/codeforamerica.org/g/brigadeleads/c/At0loymFW0I/m/OVC-W90yEAAJ